### PR TITLE
Remove Exception with Unsupported Constraint

### DIFF
--- a/Resources/config/builder.xml
+++ b/Resources/config/builder.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="jben87_parsley.builder.constraint" class="JBen87\ParsleyBundle\Builder\ConstraintBuilder">
             <argument type="service" id="jben87_parsley.validator.constraint_factory"/>
+            <argument type="service" id="logger" />
         </service>
     </services>
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/symfony": "^2.3|^3.0"
+        "symfony/symfony": "^2.3|^3.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",


### PR DESCRIPTION
The extension is used for all the form. this can be an issue if we use custom or unsupported constraint.

It's preferable to not apply parsley to the field without supported constraint to throw an exception