### PR TITLE
Add datetime range validator

### DIFF
--- a/Tests/Unit/Validator/Constraints/MaxTest.php
+++ b/Tests/Unit/Validator/Constraints/MaxTest.php
@@ -49,6 +49,11 @@ class MaxTest extends Constraint
             'max' => 10,
             'message' => 'Invalid',
         ]);
+
+        new Max([
+            'max' => '2017-04-20 00:30',
+            'message' => 'Invalid datetime',
+        ]);
     }
 
     /**

--- a/Tests/Unit/Validator/Constraints/MinTest.php
+++ b/Tests/Unit/Validator/Constraints/MinTest.php
@@ -49,6 +49,11 @@ class MinTest extends Constraint
             'min' => 5,
             'message' => 'Invalid',
         ]);
+
+        new Min([
+            'min' => '2017-04-20 00:01',
+            'message' => 'Invalid datetime',
+        ]);
     }
 
     /**

--- a/Tests/Unit/Validator/Constraints/RangeTest.php
+++ b/Tests/Unit/Validator/Constraints/RangeTest.php
@@ -83,6 +83,13 @@ class RangeTest extends Constraint
             'minMessage' => 'Too short',
             'maxMessage' => 'Too long',
         ]);
+
+        new Range([
+            'min' => '2017-04-20 00:01',
+            'max' => '2017-04-20 00:30',
+            'minMessage' => 'Not a valid datetime',
+            'maxMessage' => 'Not a valid datetime',
+        ]);
     }
 
     /**

--- a/Validator/Constraints/Max.php
+++ b/Validator/Constraints/Max.php
@@ -49,7 +49,7 @@ class Max extends Constraint
         $resolver->setRequired(['max']);
 
         if (method_exists($resolver, 'setDefined')) {
-            $resolver->setAllowedTypes('max', ['int']);
+            $resolver->setAllowedTypes('max', ['int', 'string']);
         } else {
             $resolver->setAllowedTypes([
                 'max' => 'int',

--- a/Validator/Constraints/Min.php
+++ b/Validator/Constraints/Min.php
@@ -49,7 +49,7 @@ class Min extends Constraint
         $resolver->setRequired(['min']);
 
         if (method_exists($resolver, 'setDefined')) {
-            $resolver->setAllowedTypes('min', ['int']);
+            $resolver->setAllowedTypes('min', ['int', 'string']);
         } else {
             $resolver->setAllowedTypes([
                 'min' => 'int',

--- a/Validator/Constraints/Range.php
+++ b/Validator/Constraints/Range.php
@@ -63,8 +63,8 @@ class Range extends Constraint
 
         if (method_exists($resolver, 'setDefined')) {
             $resolver
-                ->setAllowedTypes('min', ['int'])
-                ->setAllowedTypes('max', ['int']);
+                ->setAllowedTypes('min', ['int', 'string'])
+                ->setAllowedTypes('max', ['int', 'string']);
         } else {
             $resolver->setAllowedTypes([
                 'min' => 'int',


### PR DESCRIPTION
I added the type "string" in the allowed types for Max, Min and Range, that allow to use range asserts on DateTime fields without any error. Of course, the js validation does not work for these string range assert.

I also added corresponding tests.