### PR TITLE
Fix symfony 6.3 deprecation warnings in FactoryTrait.php

### DIFF
--- a/src/Constraint/Factory/FactoryTrait.php
+++ b/src/Constraint/Factory/FactoryTrait.php
@@ -11,6 +11,9 @@ trait FactoryTrait
 {
     private TranslatorInterface $translator;
 
+    /**
+     * @required
+     */
     #[Required]
     public function setTranslator(TranslatorInterface $translator): void
     {

--- a/src/Constraint/Factory/FactoryTrait.php
+++ b/src/Constraint/Factory/FactoryTrait.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace JBen87\ParsleyBundle\Constraint\Factory;
 
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 trait FactoryTrait
 {
     private TranslatorInterface $translator;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;


### PR DESCRIPTION
Replaces the @required annotation with the corresponding attribute in order to fix symfony 6.3 deprecation warnings.
This change introduces a BC break with PHP installations < 8.0.